### PR TITLE
Update API specification

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -16,6 +16,8 @@ Entry point for REST API
 
 Authenticates a user & generates a session token for authenticating all other API calls
 
+Session token is a JWT which is added to the `modns-auth` cookie.
+
 ### `/api/plugins`
 
 Root directory for management of plugins
@@ -29,87 +31,88 @@ Lists plugins and their attributes in json
 Accepts optional query parameters to filter based on certain attributes (ex: `/api/plugins?enabled=true`)
 
 Example json response:
+
 ```json
 [{
-    "id": "adblock",                                    // unique id to use in api calls related to this plugin.
-    "name": "AdBlocker",                                // set in manifest
+    "uuid": "6c396d8e-9a93-11ed-a8fc-0242ac120002",     // unique id to use in api calls related to this plugin.
+    "friendly-name": "Ad Blocker",                      // set in manifest
     "description": "Default plugin that blocks ads",    // set in manifest
-    "home": "/var/modns/plugins/adblock/",              // position in fs
-    "modules": {                                           // info about steps this plugin implements
-        "interceptor": {                                   // info about intercept function
-            "enabled": true,                               // is intercept function enabled?
-            "position": 2,                                 // position of intercept function in checking order
-            "reason": "Will intercept and drop all requests to known ad providers"   // Description to help user understand when and why to enable a particular impl
-        }
-    },
+    "home": "/opt/modns/plugins/adblock/",              // position in fs
+    "modules": ["interceptor"],                         // list of modules this plugin implements
+    "intercept-position": 1,                            // if this plugin implements an interceptor, the position of that interceptor in the execution order
     "enabled": true                                     // allow plugins to be globally disabled even though they remain installed
 },
 {
-    "id": "lancache",
-    "name": "Lan Cache",
-    "description": "Redirects common downloads to a local caching server",
-    "home": "/var/modns/plugins/lancache/",
-    "modules": {
-        "interceptor":{
-            "enabled": true,
-            "position": 3
-        }
-    },
+    "uuid": "cd9735cb-5c12-491a-b032-6ccd8cfd6855",
+    "friendly-name": "DNS Cache",
+    "description": "Default plugin that caches results of previous requests",
+    "home": "/opt/modns/plugins/dnscache",
+    "modules": ["interceptor", "inspector"],
+    "intercept-position": 2,
+    "enabled": true
+}
+{
+    "uuid": "667bad3d-5450-453c-a8dc-b2099ba6c4ef",
+    "friendly-name": "Lan Cache",
+    "description": "Redirects common download URLs to a local caching server",
+    "home": "/opt/modns/plugins/lancache/",
+    "modules": ["interceptor"],
+    "intercept-position": null,
     "enabled": false
 },
 {
-    "id": "dnssec",
-    "name": "DNSSEC",
+    "uuid": "cd9735cb-5c12-491a-b032-6ccd8cfd6855",
+    "friendly-name": "DNSSEC Validator",
     "description": "Validates DNS responses using public key cryptography",
-    "home": "/var/modns/plugins/dnssec/",
-    "modules": {
-        "validator":{
-            "enabled": true,
-            "reason": "Enable to attempt to validate requests sent to DNSSEC compatible zones"
-        },
-        "interceptor": {
-            "enabled": true,
-            "position": 1,
-            "reason": "Enable to allow plugin to respond to DNSSEC requests from downstream"
-        }
-    },
+    "home": "/opt/modns/plugins/dnssec/",
+    "modules": ["validator"],
     "enabled": true
 },
 {
-    "id": "dot",
-    "name": "Secure DNS",
+    "uuid": "18897fca-1657-461d-b7d8-90cb5c6fb550",
+    "friendly-name": "Secure DNS resolver",
     "description": "Sends DNS request over TLS encrypted channel",
-    "home": "/var/modns/plugins/dot/",
-    "modules": {
-        "resolver":{
-            "enabled": true
-        },
-        "listener": {
-            "enabled": true,
-            "reason": "Enable to allow this server to receive Secure DNS requests"
-        }
-    },
+    "home": "/opt/modns/plugins/dot/",
+    "modules": ["resolver"],
     "enabled": true
+},
+{
+    "uuid": "a379b0ad-8e45-4713-8707-1ebc22389ec5",
+    "friendly-name": "Default Listener",
+    "description": "Default listener plugin",
+    "home": "/opt/modns/plugins/default-listener",
+    "modules": ["listener"],
+    "enabled": true
+},
+{
+    "uuid": "600a45c3-0543-4e85-92ba-7c8727142d49dot",
+    "friendly-name": "Secure DNS listener",
+    "description": "Sends DNS request over TLS encrypted channel",
+    "home": "/opt/modns/plugins/dot/",
+    "modules": ["listener"],
+    "enabled": false
 }]
 ```
 
-#### POST `/api/plugins/install?format=(zip|tar.gz|git)`
+#### POST `/api/plugins/install`
 
-CLI: `modns plugin install <archive|git>`
+CLI: `modns plugin install <archive|url>`
 
-Installs a new plugin by decompressing an uploaded archive file or by cloning a git repository
+Installs a new plugin by decompressing an archive file included in the request or downloaded from the URL in the request
 
-If `format` is `zip` or `tar.gz`, request body should be a binary file containing the plugin as an archive.
+API distinguishes between archives and links using the MIME type listed in the `content-type` http header. Accepted formats are:
 
-If `format` is `git`, request body should be an HTML form with parameters to access git repo.
+- `application/zip` for ZIP archives
+- `application/gzip` for gzipped tarballs (`.tar.gz` files)
+- `text/plain` for a URL pointing to a file to download which uses one of the above encodings
 
-#### POST `/api/plugins/uninstall?id=([0-9]+)`
+#### POST `/api/plugins/uninstall?uuid=([0-9]+)`
 
 CLI: `modns plugin uninstall <name|id>`
 
 Uninstalls a plugin by removing it from the file system.
 
-*Must restart server to reload plugins*
+Must restart server to reload plugins
 
 #### POST `/api/plugins/interceptorder`
 


### PR DESCRIPTION
- Specify exactly how session tokens are handled
- Plugins are now identified by uuids rather than their directory name
- Plugins have a "friendly name" that can be identified by users
- Plugin modules are specified as a list rather than an object
- Interceptor plugins have an additional intercept-order property
- Plugins can only be enabled or disabled globally, not per module
- Install endpoint no longer accepts git repositories as a plugin source
- Instead, endpoint can download pre-compiled archives from supplied URL
- Specify types of archives can be automatically installed
- Some minor markdown changes to calm the linter