### PR TITLE
Updates to backend errors & logging

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -19,6 +19,7 @@ uuid = { version = "1.3.0", features = ["v4", "fast-rng", "serde"] }
 serde = "1.0.154"
 serde_yaml = "0.9.19"
 clap = { version = "4.1.8", features = ["derive"] }
+anyhow = "1.0.69"
 
 [dev-dependencies]
 cfg-if = "1.0.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,7 +10,6 @@ modns-sdk ={ path = "../modns-sdk" }
 bitvec = "1.0.1"
 futures = "0.3.25"
 log = "0.4.17"
-pretty_env_logger = "0.4.0"
 tokio = { version = "1.23.0", features = ["full"] }
 tokio-stream = { version = "0.1.11", features = ["net"] }
 warp = "0.3.3"
@@ -21,6 +20,7 @@ serde_yaml = "0.9.19"
 clap = { version = "4.1.8", features = ["derive"] }
 anyhow = "1.0.69"
 thiserror = "1.0.39"
+env_logger = "0.10.0"
 
 [dev-dependencies]
 cfg-if = "1.0.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -20,6 +20,7 @@ serde = "1.0.154"
 serde_yaml = "0.9.19"
 clap = { version = "4.1.8", features = ["derive"] }
 anyhow = "1.0.69"
+thiserror = "1.0.39"
 
 [dev-dependencies]
 cfg-if = "1.0.0"

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{PathBuf, Path};
 
 use clap::{Parser, ValueEnum};
 
@@ -59,8 +59,8 @@ impl ServerConfig {
         self.plugin_path.as_ref()
     }
 
-    pub fn unix_socket(&self) -> &PathBuf {
-        &self.unix_socket
+    pub fn unix_socket(&self) -> &Path {
+        &self.unix_socket.as_ref()
     }
 
     pub fn strict_init(&self) -> bool {
@@ -79,7 +79,7 @@ impl ServerConfig {
         } 
     }
 
-    pub fn data_dir(&self) -> &PathBuf {
-        &self.data_dir
+    pub fn data_dir(&self) -> &Path {
+        &self.data_dir.as_ref()
     }
 }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -32,7 +32,16 @@ pub struct ServerConfig {
 
     /// Path to the data directory
     #[arg(short, long, default_value="./modns-data")]
-    data_dir: PathBuf
+    data_dir: PathBuf,
+
+    /// Log level to output. Can be `error` (most severe), `warn`, `info`, `debug`, or `trace` (least severe).
+    /// 
+    /// You can also specify filters per module, like `modnsd::listeners=debug,info` which sets the filter to
+    /// `info` for all modules except `modnsd::listeners`. See documentation for the Rust `log` crate for more info.
+    #[arg(short, long, default_value_t)]
+    #[cfg_attr(debug_assertions, arg(default_value="modnsd=trace,info"))]
+    log: String
+
 
 }
 
@@ -81,5 +90,9 @@ impl ServerConfig {
 
     pub fn data_dir(&self) -> &Path {
         &self.data_dir.as_ref()
+    }
+
+    pub fn log(&self) -> &str {
+        self.log.as_ref()
     }
 }

--- a/server/src/listeners/api/mod.rs
+++ b/server/src/listeners/api/mod.rs
@@ -2,6 +2,7 @@
 mod routes;
 
 use std::error::Error;
+use std::fmt::Display;
 
 use routes::*;
 
@@ -17,6 +18,34 @@ pub enum ApiListener {
     Unix(UnixListener),
 }
 
+impl Display for ApiListener {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ApiListener::Tcp(l) => {
+                let addr = l.local_addr()
+                .and_then(|a| Ok(a.to_string()))
+                .unwrap_or("unknown addr".to_owned());
+
+                write!(f, "TCP socket ({addr})")
+            },
+            ApiListener::Unix(l) => {
+                let path = match l.local_addr() {
+                    Ok(a) => {
+                        a.as_pathname()
+                        .map_or(
+                            "anonymous".to_owned(),
+                            |p| p.to_string_lossy().to_string()
+                        )
+                    },
+                    Err(e) => format!("failed to get path: {e}"),
+                };
+                
+                write!(f, "Unix socket ({path})")
+            },
+        }
+    }
+}
+
 pub async fn listen_api(listeners: Vec<ApiListener>, shutdown_channel: broadcast::Sender<()>) -> Result<(), Box<dyn Error + Sync + Send>>{
     let frontend_routes = root_redirect().or(frontend_filter()).with(warp::log("http::frontend"));
 
@@ -24,7 +53,7 @@ pub async fn listen_api(listeners: Vec<ApiListener>, shutdown_channel: broadcast
         let server = warp::serve(frontend_routes.clone());
 
         let mut shutdown_rx = shutdown_channel.subscribe();
-        log::info!("Starting API server on {l:?}");
+        log::info!("Starting API server on {l}");
 
         match l {
             ApiListener::Tcp(l) => server.serve_incoming_with_graceful_shutdown(

--- a/server/src/listeners/api/mod.rs
+++ b/server/src/listeners/api/mod.rs
@@ -1,9 +1,5 @@
 
 mod routes;
-
-use std::error::Error;
-use std::fmt::Display;
-
 use routes::*;
 
 use warp::Filter;
@@ -11,6 +7,8 @@ use tokio::net::{TcpListener, UnixListener};
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::{UnixListenerStream, TcpListenerStream};
 use futures::{future::join_all, FutureExt};
+use std::fmt::Display;
+use anyhow::Result;
 
 #[derive(Debug)]
 pub enum ApiListener {
@@ -46,8 +44,8 @@ impl Display for ApiListener {
     }
 }
 
-pub async fn listen_api(listeners: Vec<ApiListener>, shutdown_channel: broadcast::Sender<()>) -> Result<(), Box<dyn Error + Sync + Send>>{
-    let frontend_routes = root_redirect().or(frontend_filter()).with(warp::log("http::frontend"));
+pub async fn listen_api(listeners: Vec<ApiListener>, shutdown_channel: broadcast::Sender<()>) -> Result<()>{
+    let frontend_routes = root_redirect().or(frontend_filter()).with(warp::log("modnsd::listeners::api"));
 
     join_all(listeners.into_iter().map(|l| {
         let server = warp::serve(frontend_routes.clone());

--- a/server/src/listeners/mod.rs
+++ b/server/src/listeners/mod.rs
@@ -2,16 +2,15 @@
 mod api;
 mod dns;
 
-use std::sync::Arc;
-
 pub use api::ApiListener;
 pub use dns::DnsListener;
+use crate::plugins::manager::PluginManager;
+
 use tokio::sync::RwLock;
 use tokio::sync::broadcast;
 use tokio::signal::unix::{signal, SignalKind};
-
-use crate::ErrorBox;
-use crate::plugins::manager::PluginManager;
+use std::sync::Arc;
+use anyhow::Result;
 
 /// Start API and DNS servers on the provided listeners
 pub async fn listen(apiaddrs: Vec<api::ApiListener>, dnsaddrs: Vec<dns::DnsListener>, pm_arc: Arc<RwLock<PluginManager>>) {
@@ -30,7 +29,7 @@ pub async fn listen(apiaddrs: Vec<api::ApiListener>, dnsaddrs: Vec<dns::DnsListe
 
 /// Listens for shutdown signals (either SIGINT or SIGTERM) and broadcasts
 /// a shutdown command on the supplied broadcast channel
-async fn wait_for_shutdown(tx: broadcast::Sender<()>) -> Result<(), ErrorBox> {
+async fn wait_for_shutdown(tx: broadcast::Sender<()>) -> Result<()> {
 
     let mut sigint = signal(SignalKind::interrupt())?;
     let mut sigterm = signal(SignalKind::terminate())?;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -12,9 +12,15 @@ mod config;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
 
-    pretty_env_logger::init();
-
     let config = config::ServerConfig::parse();
+
+    env_logger::Builder::from_env(
+        env_logger::Env::new()
+        .filter("MODNS_LOG")
+        .write_style("MODNS_LOG_STYLE")
+    )
+    .parse_filters(config.log())
+    .init();
 
     let pm_arc = Arc::new(RwLock::new(PluginManager::new()));
 

--- a/server/src/plugins/plugin.rs
+++ b/server/src/plugins/plugin.rs
@@ -21,7 +21,7 @@ pub enum PluginLoaderError {
     LibraryLoadError(libloading::Error),
     #[error("unable to open manifest.yaml")]
     ManifestOpenError(io::Error),
-    #[error("unable tor read manifest.yaml")]
+    #[error("unable to read manifest.yaml")]
     ManifestReadError(serde_yaml::Error),
 }
 

--- a/server/src/plugins/plugin.rs
+++ b/server/src/plugins/plugin.rs
@@ -1,10 +1,11 @@
 
 use super::{ListenerDecodeFn, ListenerEncodeFn, ResolverFn};
-use libloading::{Symbol, Library};
 use modns_sdk::ffi;
-use serde::Deserialize;
 
-use std::error::Error;
+use libloading::{Symbol, Library};
+use serde::Deserialize;
+use thiserror::Error;
+
 use std::fmt::Display;
 use std::{fs, io};
 use std::path::{PathBuf, Path};
@@ -14,13 +15,14 @@ const DECODER_FN_NAME: &[u8] = b"impl_decode_req";
 const ENCODER_FN_NAME: &[u8] = b"impl_encode_resp";
 const RESOLVER_FN_NAME: &[u8] = b"impl_resolve_req";
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum PluginLoaderError {
+    #[error("unable to load library")]
     LibraryLoadError(libloading::Error),
+    #[error("unable to open manifest.yaml")]
     ManifestOpenError(io::Error),
+    #[error("unable tor read manifest.yaml")]
     ManifestReadError(serde_yaml::Error),
-    NoListeners,
-    NoResolvers,
 }
 
 impl From<libloading::Error> for PluginLoaderError {
@@ -61,7 +63,6 @@ impl Display for PluginExecutorError {
         }
     }
 }
-impl Error for PluginExecutorError {}
 
 impl From<u8> for PluginExecutorError {
     fn from(value: u8) -> Self {

--- a/server/tests/listener.rs
+++ b/server/tests/listener.rs
@@ -55,7 +55,7 @@ fn listener_plugin_decoder_success() {
 
     let mut pm = PluginManager::new();
 
-    pm.search(&[PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("../plugins")]);
+    pm.search(&[PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("../plugins")]).unwrap();
 
     let test_response = pm.decode(&SAMPLE_REQUEST[..]).unwrap();
 
@@ -111,7 +111,7 @@ fn listener_plugin_decoder_success() {
 fn listener_plugin_decoder_failure() {
     let mut pm = PluginManager::new();
 
-    pm.search(&[PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("../plugins")]);
+    pm.search(&[PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("../plugins")]).unwrap();
 
     let test_response = pm.decode(&SAMPLE_REQUEST[..20]);
 
@@ -126,7 +126,7 @@ fn listener_plugin_decoder_failure() {
 fn listener_plugin_encoder_success() {
     let mut pm = PluginManager::new();
 
-    pm.search(&[PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("../plugins")]);
+    pm.search(&[PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("../plugins")]).unwrap();
 
     let message = Box::new(ffi::DnsMessage {
             header: SAMPLE_REQUEST_HEADER,


### PR DESCRIPTION
Various changes to error handling & logging to help with troubleshooting down the road. Namely:

Added `anyhow` crate to provide helpful context to errors

Added `thiserror` crate to make constructing errors easier

Implemented `--ignore-init-errors` flag

Added `--log` flag to specify log variable

Switched environment variable for logging level to `MODNS_LOG`