### PR TITLE
Dynamically compose server configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+/modns-data

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -19,6 +19,7 @@ uuid = { version = "1.3.0", features = ["v4", "fast-rng", "serde"] }
 serde = "1.0.154"
 serde_yaml = "0.9.19"
 clap = { version = "4.1.8", features = ["derive"] }
+anyhow = "1.0.70"
 
 [dev-dependencies]
 cfg-if = "1.0.0"

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -16,7 +16,12 @@ const LOG_ENV: &str = "MODNS_LOG";
 const DEFAULT_PLUGIN_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../plugins");
 const DEFAULT_UNIX_SOCKET: &str = "/tmp/modnsd.sock";
 const DEFAULT_DATA_DIR: &str = "modns-data";
+
+#[cfg(debug_assertions)]
 const DEFAULT_LOG_FILTER: &str = "modnsd=trace,info";
+
+#[cfg(not(debug_assertions))]
+const DEFAULT_LOG_FILTER: &str = "info";
 
 const DATA_DIR_FALLBACK_PARENT: &str = "/tmp";
 

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -1,15 +1,22 @@
-use std::path::PathBuf;
+use std::{path::{PathBuf, Path}, fs, env::{self, VarError}};
 
+use anyhow::Context;
 use clap::{Parser, ValueEnum};
+use serde::Deserialize;
+
+const PLUGIN_PATH_ENV: &str = "MODNS_PATH";
+const UNIX_SOCKET_ENV: &str = "MODNS_UNIX_SOCKET";
+const IGNORE_ERRS_ENV: &str = "MODNS_IGNORE_INIT_ERRORS";
+const DATA_DIR_ENV: &str = "MODNS_DATA_DIR";
 
 /// A modular DNS resolver
 /// 
 /// MoDNS is a DNS server that uses plugins to provide all functionality
 /// 
 /// This program is the server daemon. If you want to control an already running server, use `modns` instead
-#[derive(Parser)]
+#[derive(Parser, Deserialize)]
 #[command(name = "modnsd")]
-pub struct ServerConfig {
+pub struct ServerConfigBuilder {
 
     /// Directory to search for plugins.
     /// 
@@ -24,7 +31,7 @@ pub struct ServerConfig {
 
     /// Path for the Unix Domain socket that is used by the CLI
     #[arg(short, long, default_value="/tmp/modnsd.sock")]
-    unix_socket: PathBuf,
+    unix_socket: Option<PathBuf>,
 
     /// Ignore some, all, or no errors when initially loading plugins
     /// 
@@ -32,21 +39,130 @@ pub struct ServerConfig {
     /// load, but if all plugins are loaded and the server is unable to handle
     /// DNS requests (most likely because there isn't a Resolver or Listener
     /// enabled), server will immediately exit with an error code
-    #[arg(short, long, value_enum, default_value_t)]
-    ignore_init_errors: IgnoreErrorsConfig,
+    #[arg(short, long, value_enum)]
+    ignore_init_errors: Option<IgnoreErrorsConfig>,
 
     /// Path to the data directory
     #[arg(short, long, default_value="./modns-data")]
-    data_dir: PathBuf
+    data_dir: Option<PathBuf>
 
 }
 
-#[derive(Clone, Copy, ValueEnum, Default)]
+impl ServerConfigBuilder {
+    pub fn from_args() -> anyhow::Result<Self> {
+        Self::try_parse().context("Failed to parse configuration from arguments")
+    }
+
+    pub fn from_yaml_file<P: AsRef<Path>>(config_file_path: P) -> anyhow::Result<Self> {
+        let f = fs::read_to_string(config_file_path).context("Failed to read configuration file")?;
+        serde_yaml::from_str(&f).context("Failed to parse configuration file")
+
+    }
+
+    pub fn from_env() -> Self {
+
+        let plugin_path = env::var(PLUGIN_PATH_ENV).ok()
+        .unwrap_or_default()
+        .split(":")
+        .filter_map(|s| PathBuf::from(s).canonicalize().ok()).collect();
+
+        let unix_socket = env::var(UNIX_SOCKET_ENV).ok()
+        .and_then(|s| PathBuf::from(s).canonicalize().ok());
+
+        let ignore_init_errors = env::var(IGNORE_ERRS_ENV).ok()
+        .and_then(|s| IgnoreErrorsConfig::from_str(&s, true).ok());
+
+        let data_dir = env::var(DATA_DIR_ENV).ok()
+        .and_then(|s| PathBuf::from(s).canonicalize().ok());
+
+        Self {
+            plugin_path,
+            unix_socket,
+            ignore_init_errors,
+            data_dir,
+        }
+    }
+
+    pub fn merge(self, other: Self) -> Self {
+
+        let Self {
+            mut plugin_path,
+            unix_socket,
+            ignore_init_errors,
+            data_dir,
+        } = self;
+
+        plugin_path.extend(other.plugin_path);
+
+        let unix_socket = match (unix_socket, other.unix_socket) {
+            (Some(p), _) => Some(p),
+            (None, Some(p)) => Some(p),
+            (None, None) => None,
+        };
+
+        let ignore_init_errors = match (ignore_init_errors, other.ignore_init_errors) {
+            (Some(p), _) => Some(p),
+            (None, Some(p)) => Some(p),
+            (None, None) => None,
+        };
+
+        let data_dir = match (data_dir, other.data_dir) {
+            (Some(p), _) => Some(p),
+            (None, Some(p)) => Some(p),
+            (None, None) => None,
+        };
+
+        Self {
+            plugin_path,
+            unix_socket,
+            ignore_init_errors,
+            data_dir,
+        }
+
+    }
+
+    fn reverse_merge(self, other: Self) -> Self {
+        Self::merge(other, self)
+    }
+
+    fn build(self) -> anyhow::Result<ServerConfig> {
+        let Self {
+            plugin_path,
+            unix_socket,
+            ignore_init_errors,
+            data_dir,
+        } = self;
+
+        Ok(ServerConfig {
+            plugin_path,
+            unix_socket: unix_socket.unwrap_or(PathBuf::from("/tmp/modnsd.sock")),
+            ignore_init_errors: ignore_init_errors.unwrap_or_default(),
+            data_dir: data_dir.unwrap_or(PathBuf::from("./modns-data").canonicalize()?),
+        })
+    }
+}
+
+#[derive(Clone, Copy, ValueEnum, Default, Deserialize)]
 pub enum IgnoreErrorsConfig {
     Always,
     #[default]
     Default,
     Never
+}
+
+pub struct ServerConfig {
+
+    /// Directories to search for plugin directories
+    plugin_path: Vec<PathBuf>,
+
+    /// Path to the API's unix socket
+    unix_socket: PathBuf,
+
+    /// Setting the user chose of whether to ignore plugin initialization errors
+    ignore_init_errors: IgnoreErrorsConfig,
+
+    /// Directory to store persistent data files in
+    data_dir: PathBuf,
 }
 
 impl ServerConfig {
@@ -81,4 +197,12 @@ impl ServerConfig {
     pub fn data_dir(&self) -> &PathBuf {
         &self.data_dir
     }
+}
+
+pub fn init() -> anyhow::Result<ServerConfig> {
+
+    ServerConfigBuilder::from_env()
+    .merge(ServerConfigBuilder::from_args()?)
+    .build()
+
 }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -250,7 +250,7 @@ impl ServerConfig {
     {
 
         // Get canonical paths for all plugin directories, creating any directories that don't exist
-        let plugin_path = plugin_path.into_iter().map(|p| {
+        let mut plugin_path = plugin_path.into_iter().map(|p| {
 
             if !p.as_ref().is_dir() {
                 fs::create_dir_all(p.as_ref())
@@ -260,6 +260,10 @@ impl ServerConfig {
             p.as_ref().canonicalize().with_context(|| format!("Plugin directory {} was not found", p.as_ref().display()))
 
         }).collect::<Result<Vec<PathBuf>>>()?;
+
+        // Ensure that no paths point to the same place
+        plugin_path.sort_unstable();
+        plugin_path.dedup();
 
         // Server will attempt to create unix socket, so we should make sure it doesn't exist, but the directory it's in does
         if unix_socket.as_ref().try_exists()

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,9 +1,8 @@
 use std::error::Error;
 use std::sync::Arc;
 
+use anyhow::Context;
 use modnsd::plugins::manager::PluginManager;
-use clap::Parser;
-use modnsd::plugins::executors::PluginManager;
 use modnsd::listeners::{ApiListener, DnsListener, self};
 use tokio::{net::{TcpListener, UnixListener, UdpSocket}, sync::RwLock};
 
@@ -14,7 +13,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     pretty_env_logger::init();
 
-    let config = config::ServerConfig::parse();
+    let config = config::init().context("Failed to load configuration")?;
 
     let pm_arc = Arc::new(RwLock::new(PluginManager::new()));
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -21,6 +21,8 @@ async fn main() -> anyhow::Result<()> {
     .parse_filters(config.log())
     .init();
 
+    log::trace!("Starting server with configuration: {:#?}", config);
+
     let pm_arc = Arc::new(RwLock::new(PluginManager::new()));
 
     {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,7 +1,6 @@
 use std::error::Error;
 use std::sync::Arc;
 
-use anyhow::Context;
 use modnsd::plugins::manager::PluginManager;
 use modnsd::listeners::{ApiListener, DnsListener, self};
 use tokio::{net::{TcpListener, UnixListener, UdpSocket}, sync::RwLock};
@@ -13,7 +12,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     pretty_env_logger::init();
 
-    let config = config::init().context("Failed to load configuration")?;
+    let config = config::init()?;
 
     let pm_arc = Arc::new(RwLock::new(PluginManager::new()));
 


### PR DESCRIPTION
Refactors server configuration to use a builder which can compose configuration options from multiple sources.

Adds default configuration init() function that pulls from environment variables, then arguments, then fills in any unspecified configuration options with their previous values