### PR TITLE
Minor updates to CI workflows

### DIFF
--- a/.github/workflows/backend-workflow.yml
+++ b/.github/workflows/backend-workflow.yml
@@ -71,6 +71,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: backend-build
+        retention-days: 1
         path: |
           target/${{ inputs.rust_toolchain }}/debug/modns
           target/${{ inputs.rust_toolchain }}/debug/modnsd

--- a/.github/workflows/backend-workflow.yml
+++ b/.github/workflows/backend-workflow.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Save artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: backend-build-${{ inputs.architecture }}
+        name: backend-build
         path: |
           target/${{ inputs.rust_toolchain }}/debug/modns
           target/${{ inputs.rust_toolchain }}/debug/modnsd

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -48,5 +48,5 @@ jobs:
           ci-build-x86_64-
     - uses: actions/download-artifact@v3
       with:
-        name: backend-build-x86_64
+        name: backend-build
     - run: make test ARCH=x86_64

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,5 +1,7 @@
 name: CI Workflow
 
+run-name: Test PR ${{ github.ref }} by ${{ github.actor }}
+
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -5,11 +5,9 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - '**'
-      - '!docs/**'
-      - '!frontend/**'
-      - '!**Dockerfile**'
-      - '!**docker**'
+      - '**.rs'
+      - 'plugins/**'
+      - '**/Cargo.toml'
 
 jobs:
   build:
@@ -34,7 +32,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: actions/cache@v3

--- a/.github/workflows/packaging-workflow.yml
+++ b/.github/workflows/packaging-workflow.yml
@@ -1,5 +1,7 @@
 name: Package for Debian
 
+run-name: Package release ${{ inputs.version || github.ref_name }}
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/packaging-workflow.yml
+++ b/.github/workflows/packaging-workflow.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Get backend build artifacts
         uses: actions/download-artifact@v3
         with:
-          name: backend-build-${{ matrix.architecture }}
+          name: backend-build
       - name: Get frontend build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/packaging-workflow.yml
+++ b/.github/workflows/packaging-workflow.yml
@@ -88,3 +88,18 @@ jobs:
           path: |
             ${{ steps.deb.outputs.file_name }}
 
+  release:
+    runs-on: ubuntu-latest
+    needs: package
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: deb-release
+      - uses: ncipollo/release-action@v1
+        with:
+          name: Release ${{ github.ref_name }}
+          files: '*.deb'
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta')}}
+

--- a/.github/workflows/react-workflow.yml
+++ b/.github/workflows/react-workflow.yml
@@ -1,5 +1,7 @@
 name: Node.js CI
 
+run-name: Test frontend for PR ${{ github.ref }} by ${{ github.actor }}
+
 on:
   workflow_dispatch:
   workflow_call:

--- a/.github/workflows/react-workflow.yml
+++ b/.github/workflows/react-workflow.yml
@@ -32,5 +32,6 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: frontend-build
+          retention-days: 1
           path: |
             frontend/dns_frontend/build/


### PR DESCRIPTION
Packaging workflow now automatically creates release when triggered by tag

Fix backend CI to only be triggered by updates to backend (found by `.rs` files, `Cargo.toml` files, and `plugins` directory)

Other minor refactoring