### PR TITLE
Cargo buildchain fixes

### DIFF
--- a/Dockerfile.Backend.Dev
+++ b/Dockerfile.Backend.Dev
@@ -1,5 +1,5 @@
-#Use cargo-chef to build dependencies separately from main binary
-FROM rust:1.67
+FROM rust:1.69
+#nice
 
 # create Rust-based backend server working directory
 WORKDIR /rust-server
@@ -13,6 +13,12 @@ RUN cargo install cargo-watch
 # Make needs Go
 COPY --from=golang:1.20 /usr/local/go/ /usr/local/go/
 ENV PATH="/rust-server/target/debug:/usr/local/go/bin:${PATH}"
+
+# Use terminal colors when running cargo commands
+ENV CARGO_TERM_COLOR=always
+
+# Use the sparse cargo protocol, which should cut down on build times
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 EXPOSE 8080 
 EXPOSE 5300/udp

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,9 @@ services:
       - ./Makefile:/rust-server/Makefile
       - frontend_build:/usr/share/modns/web:ro
       - backend_build:/rust-server/target
+      - backend_cache:/root/.cargo/registry
 
 volumes:
   frontend_build:
   backend_build:
+  backend_cache:


### PR DESCRIPTION
Minor changes which should speed up builds using cargo in the dev environment

- Update to Rust toolchain version 1.69, which allows us to use the sparse protocol for dependency resolution
- Cache the cargo registry in `~/.cargo/registry` so we don't have to re-pull from crates.io between restarts
- Use colors when in the docker environment